### PR TITLE
✨ Feat: 응답 반환 구조 설정

### DIFF
--- a/booth/views.py
+++ b/booth/views.py
@@ -6,8 +6,11 @@ from rest_framework.filters import OrderingFilter
 from .models import Booth
 from .serializers import BoothListSerializer, BoothDetailSerializer
 from rest_framework import viewsets, mixins
+from utils.mixins import CustomResponseMixin
+from utils.responses import custom_response
+from utils.exceptions import *
 
-class BoothViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.ListModelMixin):
+class BoothViewSet(CustomResponseMixin, viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.ListModelMixin):
     queryset = Booth.objects.all()
     filter_backends = [OrderingFilter]
     ordering_fields = ['name', 'waiting_count']
@@ -32,4 +35,15 @@ class BoothViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.Li
     @action(detail=False, methods=['get'], url_path='count')
     def get_booth_count(self, request):
         booth_count = Booth.objects.count()
-        return Response({'booth_count': booth_count}, status=status.HTTP_200_OK)
+        return custom_response({'booth_count': booth_count}, message='Booth count fetched successfully')
+    
+    # 에러 띄우기 위한 함수
+    @action(detail=False, methods=['get'], url_path='error')
+    def error(self, request):
+        raise ResourceNotFound()
+    
+    # 에러 띄우기 위한 함수 mk2
+    @action(detail=False, methods=['get'], url_path='error2')
+    def error2(self, request):
+        raise CustomException()
+        return custom_response(data=None, message='This should not be reached', code=200, success=True)

--- a/linenow/settings.py
+++ b/linenow/settings.py
@@ -33,7 +33,7 @@ SECRET_KEY = env('SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env('DEBUG')
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 # Application definition
 
@@ -70,6 +70,7 @@ REST_FRAMEWORK = {
         "dj_rest_auth.jwt_auth.JWTCookieAuthentication",
         "rest_framework.authentication.SessionAuthentication",
     ),
+    'EXCEPTION_HANDLER': 'utils.exceptions.custom_exception_handler',
 }
 
 MIDDLEWARE = [

--- a/utils/exceptions.py
+++ b/utils/exceptions.py
@@ -1,0 +1,41 @@
+from rest_framework.views import exception_handler
+from rest_framework.exceptions import APIException
+from .responses import custom_response
+'''
+    커스텀 예외 처리
+    - 커스텀 예외 클래스 정의
+    - 커스텀 예외 핸들러 정의
+    
+    view에서의 사용 방법
+    import 예외클래스 from utils.exceptions
+    - raise 예외클래스('에러메시지')
+'''
+
+# 커스텀 예외 클래스
+class ResourceNotFound(APIException):
+    status_code = 404
+    default_detail = 'The requested resource was not found.'
+    default_code = 'resource_not_found'
+
+# 이 아래로 class를 만들어 커스텀 예외를 만들면 됩니다.
+# 예시
+class CustomException(APIException):
+    status_code = 400
+    default_detail = 'I hate exceptions :('
+    default_code = 'custom_exception' 
+
+
+# 커스텀 예외 핸들러
+def custom_exception_handler(exc, context):
+    """
+    커스텀 예외 핸들러
+    - DRF 기본 핸들러를 확장하여 일관된 에러 응답 제공
+    """
+    response = exception_handler(exc, context)
+
+    if response is not None:
+        message = response.data.get('detail', 'An error occurred.')
+        code = response.status_code
+        return custom_response(data=None, message=message, code=code, success=False)
+    
+    return custom_response(data=None, message='Unhandled server error occurred.', code=500, success=False)

--- a/utils/mixins.py
+++ b/utils/mixins.py
@@ -1,0 +1,25 @@
+from .responses import custom_response
+
+class CustomResponseMixin:
+    """
+    ViewSet의 기본 응답을 custom_response 형식으로 변환하는 Mixin
+    """
+    def list(self, request, *args, **kwargs):
+        response = super().list(request, *args, **kwargs)
+        return custom_response(data=response.data, message="List fetched successfully")
+
+    def retrieve(self, request, *args, **kwargs):
+        response = super().retrieve(request, *args, **kwargs)
+        return custom_response(data=response.data, message="Details fetched successfully")
+
+    def create(self, request, *args, **kwargs):
+        response = super().create(request, *args, **kwargs)
+        return custom_response(data=response.data, message="Resource created successfully", code=201)
+
+    def update(self, request, *args, **kwargs):
+        response = super().update(request, *args, **kwargs)
+        return custom_response(data=response.data, message="Resource updated successfully")
+
+    def destroy(self, request, *args, **kwargs):
+        response = super().destroy(request, *args, **kwargs)
+        return custom_response(data=None, message="Resource deleted successfully", code=204)

--- a/utils/responses.py
+++ b/utils/responses.py
@@ -1,0 +1,18 @@
+from rest_framework.response import Response
+from rest_framework import status
+
+def custom_response(data=None, message='Success', code=status.HTTP_200_OK, success=True):
+    """
+    커스텀 응답 함수
+    - data: 실제 응답 데이터
+    - message: 응답 메시지
+    - code: HTTP 상태 코드
+    - success: 성공 여부 (True면 'success', False면 'error')
+    """
+    response = {
+        'status': 'success' if success else 'error',
+        'message': message,
+        'code': code,
+        'data': data if data is not None else None  # 데이터가 없으면 null 반환
+    }
+    return Response(response, status=code)


### PR DESCRIPTION
기본 response와 error 응답 반환 구조를 설정하였습니다. mixin을 커스텀하여 기본 응답 구조를 수정했으며, custom response도 사용 가능하도록 했습니다. exceptions.py를 통해 예외 처리 커스텀이 가능합니다.

# 🔥 Pull requests

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
기본 response와 error 응답 반환 구조를 설정하였습니다. mixin을 커스텀하여 기본 응답 구조를 수정했으며, custom response도 사용 가능하도록 했습니다. exceptions.py를 통해 예외 처리 커스텀이 가능합니다.


## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
앞으로 generic viesets과 mixin을 사용할 때 from utils.mixins import CustomResponseMixin 를 import 후의 아래처럼 BoothViewSet(**CustomResponseMixin**, viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.ListModelMixin):
CustomResponseMixin을 선언해주셔야 합니다.

또, 예외처리 시에 커스텀 에러 처리는 utils/exceptions.py에 새로운 클래스를 만들어 적용하시면 됩니다.
```python
class CustomException(APIException):
    status_code = 400
    default_detail = 'I hate exceptions :('
    default_code = 'custom_exception' 
```
여기서 detail은 기본 메시지이며, code 는 식별 코드입니다. 에러 식별자라고 생각해주시면 될 것 같습니다. 
view에서의 사용 방법은 아래와 같습니다.
```python
    # import 방법
    from utils.responses import custom_response
    from utils.exceptions import *

    # custom_response 사용 방법
    @action(detail=False, methods=['get'], url_path='count')
    def get_booth_count(self, request):
        booth_count = Booth.objects.count()
        return custom_response({'booth_count': booth_count}, message='Booth count fetched successfully')

    # 에러 띄우기 위한 함수
    @action(detail=False, methods=['get'], url_path='error')
    def error(self, request):
        raise ResourceNotFound()
    
    # 에러 띄우기 위한 함수 mk2
    @action(detail=False, methods=['get'], url_path='error2')
    def error2(self, request):
        raise CustomException()
        # 여기서는 exception이 일어나면 custom_response가 반환 되지 않는 것을 확인하는 부분입니다.
        return custom_response(data=None, message='This should not be reached', code=200, success=True)

```


## 📸 스크린샷
<!-- 구현한 기능의 웹 혹은 postman을 캡쳐해주세요. -->
<img width="548" alt="image" src="https://github.com/user-attachments/assets/f445d51a-ae6f-42ef-83bf-55f76efebe95">

<img width="643" alt="image" src="https://github.com/user-attachments/assets/480b11ca-013e-41f8-98ab-231813888e2a">

<img width="545" alt="image" src="https://github.com/user-attachments/assets/1dfe2f31-48e2-4918-9b76-3ef29a0b3c44">


## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
- 쏼라쏼라
```python
def custom_response(data=None, message='Success', code=status.HTTP_200_OK, success=True):
    """
    커스텀 응답 함수
    - data: 실제 응답 데이터
    - message: 응답 메시지
    - code: HTTP 상태 코드
    - success: 성공 여부 (True면 'success', False면 'error')
    """
    response = {
        'status': 'success' if success else 'error',
        'message': message,
        'code': code,
        'data': data if data is not None else None  # 데이터가 없으면 null 반환
    }
    return Response(response, status=code)

# 커스텀 예외 핸들러
def custom_exception_handler(exc, context):
    """
    커스텀 예외 핸들러
    - DRF 기본 핸들러를 확장하여 일관된 에러 응답 제공
    """
    response = exception_handler(exc, context)

    if response is not None:
        message = response.data.get('detail', 'An error occurred.')
        code = response.status_code
        return custom_response(data=None, message=message, code=code, success=False)
    
    return custom_response(data=None, message='Unhandled server error occurred.', code=500, success=False)

class CustomResponseMixin:
    """
    ViewSet의 기본 응답을 custom_response 형식으로 변환하는 Mixin
    """
    def list(self, request, *args, **kwargs):
        response = super().list(request, *args, **kwargs)
        return custom_response(data=response.data, message="List fetched successfully")
    # 이하 오버라이딩 함수 생략
```


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?


## 📟 관련 이슈
- Resolved: #10
