### PR TITLE
🐛Fix: CORS 허용 코드 추가

### DIFF
--- a/linenow/settings.py
+++ b/linenow/settings.py
@@ -209,6 +209,22 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
+# corsheaders
+CORS_ALLOW_ALL_ORIGINS = False
+CORS_ALLOW_CREDENTIALS = True
+
+CORS_ALLOWED_ORIGINS = [
+    # 로컬 개발용 주소
+    'http://localhost:3000', 
+    'http://localhost:5173', 
+    'http://127.0.0.1:3000', 
+    'http://127.0.0.1:5173',
+    'http://127.0.0.1:8000',
+
+    # 프론트엔드 도메인 또는 IP주소
+    ''
+]
+
 # Celery 관련 설정
 CELERY_BROKER_URL = env('CELERY_BROKER_URL')  # Redis 브로커 주소
 CELERY_RESULT_BACKEND = env('CELERY_RESULT_BACKEND')  # 결과 백엔드 주소


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
settings.py에 CORS 허용 코드 추가했습니다. 현재는 개발용 로컬 주소만 작성하였습니다.

## 🚨 참고 사항
프론트 배포 이후 배포 주소 추가 작성 필요합니다.

## 📸 스크린샷


## 🖥️ 주요 코드 설명
```python
# corsheaders
CORS_ALLOW_ALL_ORIGINS = False
CORS_ALLOW_CREDENTIALS = True

CORS_ALLOWED_ORIGINS = [
    # 로컬 개발용 주소
    'http://localhost:3000', 
    'http://localhost:5173', 
    'http://127.0.0.1:3000', 
    'http://127.0.0.1:5173',
    'http://127.0.0.1:8000',

    # 프론트엔드 도메인 또는 IP주소
    ''
]
```


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?


## 📟 관련 이슈
- Resolved: 
