### PR TITLE
💚 Fix: docker SSL 인증서 발급 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,7 @@ RUN apt-get update && apt-get install -y \
     gcc \
     default-libmysqlclient-dev \
     pkg-config
-
-    # certbot으로 SSL 인증서 발급
-    apt-get install python3-certbot-nginx
-    certbot certonly --nginx -d linenow.xyz
+    python3-certbot-nginx
 
 # 작업 디렉토리 설정
 WORKDIR /app
@@ -22,4 +19,4 @@ RUN pip install -r /app/requirements.txt
 COPY . /app
 
 # makemigrations, migrate 실행 후 Gunicorn 시작
-CMD ["sh", "-c", "python manage.py makemigrations --noinput && python manage.py migrate --noinput && gunicorn linenow.wsgi:application --bind 0.0.0.0:8000"]
+CMD ["sh", "-c", "python manage.py makemigrations --noinput && python manage.py migrate --noinput && certbot certonly --nginx -d linenow.xyz && gunicorn linenow.wsgi:application --bind 0.0.0.0:8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ RUN apt-get update && apt-get install -y \
     default-libmysqlclient-dev \
     pkg-config
 
+    # certbot으로 SSL 인증서 발급
+    apt-get install python3-certbot-nginx
+    certbot certonly --nginx -d linenow.xyz
+
 # 작업 디렉토리 설정
 WORKDIR /app
 

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -34,11 +34,11 @@ def kakao_callback(request):
     # 로그인 또는 회원가입 처리
     data = {"access_token": kakao_access_token, "code": code}
     accept = requests.post(f"{BACK_BASE_URL}api/v1/accounts/kakao/login/finish/", data=data)
-
     if accept.status_code != 200:
         raise InvalidToken("Authentication Failed.")
 
     accept_json = accept.json()
+    user = accept_json.get('user')
     access_token = accept_json['access']
     refresh_token = accept.cookies.get('refresh_token')
 
@@ -47,7 +47,8 @@ def kakao_callback(request):
 
     data = {
         "access_token": access_token,
-        "refresh_token": refresh_token
+        "refresh_token": refresh_token,
+        "user":user
     }
 
     return custom_response(data=data, message="Login successful.", code=status.HTTP_200_OK)


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
HTTPS 배포를 위해 SSL 인증서가 필요하여, Dockerfile에 certbot으로 인증서 발급하는 부분을 추가했습니다.

accounts.views.py에 로그인 시, user 반환하는 부분도 추가했습니다.

## 🚨 참고 사항

## 📸 스크린샷


## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
- 쏼라쏼라
```python
// 코드는 이 사이에 작성하면 됩니다. 
```


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?


## 📟 관련 이슈
- Resolved: #이슈번호
