### PR TITLE
🩹 Fix: 입장 확정 후 10분 지나면 '시간 초과로 인한 대기 취소'로 상태 변경

### DIFF
--- a/waiting/tasks.py
+++ b/waiting/tasks.py
@@ -15,12 +15,12 @@ def check_ready_to_confirm(waiting_id):
 
 @shared_task
 def check_confirmed(waiting_id):
-    """10분 후 입장 확정 상태에서 도착하지 않으면 취소"""
+    """10분 후 입장 확정 상태에서 도착하지 않으면 time_over_canceled 상태로 변경"""
     from .models import Waiting
     try:
         waiting = Waiting.objects.get(pk=waiting_id)
         # 10분이 지났으면 취소 처리
-        if waiting.is_confirmed_expired():
-            waiting.set_canceled()  # 대기 취소 처리
+        if waiting.is_confirmed_expired() and waiting.waiting_status == 'confirmed':
+            waiting.set_time_over_canceled()  # 시간 초과로 취소 처리
     except Waiting.DoesNotExist:
         pass


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
입장 확정 후 10분 지나면 '시간 초과로 인한 대기 취소'로 상태 변경

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
