### PR TITLE
🐛 Fix: 대기자 호출 오류 수정

### DIFF
--- a/linenow/settings.py
+++ b/linenow/settings.py
@@ -106,7 +106,7 @@ REST_AUTH = {
 REST_USE_JWT = True
 
 SIMPLE_JWT = {
-    'ACCESS_TOKEN_LIFETIME': timedelta(hours=2),
+    'ACCESS_TOKEN_LIFETIME': timedelta(days=7),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=14),
     'ROTATE_REFRESH_TOKENS': True,
     'BLACKLIST_AFTER_ROTATION': True,

--- a/manager/views.py
+++ b/manager/views.py
@@ -144,14 +144,14 @@ class BoothWaitingViewSet(CustomResponseMixin, mixins.ListModelMixin, mixins.Ret
             waiting.ready_to_confirm_at = timezone.now()
             check_ready_to_confirm.apply_async((waiting.id,), countdown=180)  # 3분 후 Task 실행
         elif action == 'confirm':
-            if waiting.waiting_status != 'confirmed' :
+            if waiting.waiting_status != 'ready_to_confirm' :
                 return custom_response(
                     data=None,
                     message="Cannot confirm team while it is not confirmed.",
                     code=status.HTTP_400_BAD_REQUEST,
                     success=False
                 )
-            waiting.waiting_status = 'arrived'
+            waiting.waiting_status = 'confirmed'
             waiting.confirmed_at = timezone.now()
             # 문자 메시지 발송
             phone_number = waiting.user.phone_number


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
대기자 호출 부분에 오류가 있어서, 입장 문자가 보내지지 않는 부분 수정했습니다.


## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->


## 📸 스크린샷
<!-- 구현한 기능의 웹 혹은 postman을 캡쳐해주세요. -->


## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
- 쏼라쏼라
```python
        elif action == 'confirm':
            if waiting.waiting_status != 'ready_to_confirm' :
                return custom_response(
                    data=None,
                    message="Cannot confirm team while it is not confirmed.",
                    code=status.HTTP_400_BAD_REQUEST,
                    success=False
                )
            waiting.waiting_status = 'confirmed'
            waiting.confirmed_at = timezone.now()
            # 문자 메시지 발송
            phone_number = waiting.user.phone_number
            sendsms(phone_number, f"[라인나우] 입장 순서가 되었어요. 3분 내로 입장을 확정해 주세요!")
```


## ✅ Check List
- [ ] Merge 대상 브랜치가 올바른가?
- [ ] 최종 코드가 에러 없이 잘 동작하는가?


## 📟 관련 이슈
- Resolved: #이슈번호
