### PR TITLE
🐛 Fix: now-waiting에 취소외 3가지 상태 응답

### DIFF
--- a/waiting/views.py
+++ b/waiting/views.py
@@ -105,6 +105,6 @@ class WaitingViewSet(viewsets.GenericViewSet):
     @action(detail=False, methods=['get'], url_path='now-waitings')
     def waiting_list(self, request):
         user = request.user
-        queryset = Waiting.objects.filter(user=user, waiting_status='waiting')
+        queryset = Waiting.objects.filter(user=user, waiting_status__in=['waiting','ready_to_confirm','confirmed'])
         serializer = self.get_serializer(queryset, many=True)
         return custom_response(data=serializer.data, message="My now waiting list fetched successfully.", code=status.HTTP_200_OK)


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
now-waitings에서
"현재 대기 중인 것들만 보내요…
대기, 입장확정, 입장 중 다 보내주셔야합니다" - 프론트
=> 이부분 수정했습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->


## 📸 스크린샷
<!-- 구현한 기능의 웹 혹은 postman을 캡쳐해주세요. -->


## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
- 쏼라쏼라
```python
// 코드는 이 사이에 작성하면 됩니다. 
```


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?


## 📟 관련 이슈
- Resolved: #이슈번호
