### PR TITLE
✨ Feat: [관리자] status별 웨이팅 팀 수 API 추가

### DIFF
--- a/manager/urls.py
+++ b/manager/urls.py
@@ -20,8 +20,7 @@ urlpatterns = [
     path('manager/', include(booth_detail_router.urls)),
     path('manager/login', AdminLoginView.as_view(), name='admin_login'),
     path('manager/logout', AdminLogoutView.as_view(), name='admin_logout'),
-
-    
+    path('manager/waiting-counts', WaitingCountView.as_view(), name='waiting_counts'),
     # path('manager/waitings', BoothWaitingListView.as_view(), name='booth_waiting_list'),
     # path('manager/waitings/status/<str:status_group>', BoothWaitingStatusFilterView.as_view(), name='booth_waiting_status_filter'),
 

--- a/manager/views.py
+++ b/manager/views.py
@@ -307,3 +307,28 @@ class BoothDetailViewSet(CustomResponseMixin, viewsets.GenericViewSet, mixins.Re
             message="Booth waiting status changed to operating.",
             code=status.HTTP_200_OK
         )
+
+# 상태별 웨이팅 개수 카운트
+class WaitingCountView(APIView):
+    authentication_classes = [JWTAuthentication]
+    permission_classes = [IsAuthenticated, IsAdminUser]
+    
+    def get(self, request):
+        admin = self.request.admin
+        booth = admin.booth
+
+        waiting_count = WaitingFilter({'status': 'waiting'}, queryset=Waiting.objects.filter(booth=booth)).qs.count()
+        calling_count = WaitingFilter({'status': 'calling'}, queryset=Waiting.objects.filter(booth=booth)).qs.count()
+        arrived_count = WaitingFilter({'status': 'arrived'}, queryset=Waiting.objects.filter(booth=booth)).qs.count()
+        canceled_count = WaitingFilter({'status': 'canceled'}, queryset=Waiting.objects.filter(booth=booth)).qs.count()
+
+        return custom_response(
+            data={
+                "waiting": waiting_count,
+                "calling": calling_count,
+                "arrived": arrived_count,
+                "canceled": canceled_count
+            },
+            message="Waiting counts fetched successfully",
+            code=status.HTTP_200_OK
+        )


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
<img width="640" alt="스크린샷 2024-10-07 오전 9 24 52" src="https://github.com/user-attachments/assets/eeee2d66-21cc-4d1c-bc8a-eb8e5bd50bba">

백엔드에서 위의 내용 보내줄 수 있도록 API 구현하였습니다.



## 📸 스크린샷
<img width="1120" alt="스크린샷 2024-10-07 오전 9 25 13" src="https://github.com/user-attachments/assets/9d2ad7ef-cf0a-45da-a03d-09634197be56">



## 🖥️ 주요 코드 설명
종범행님이 야무지게 만들어두신 WaitingFilter를 이용해보고 싶어서 아래의 코드를 작성하였는데 .. 더 깔끔한진 모르겠네요 

```python
# 상태별 웨이팅 개수 카운트
class WaitingCountView(APIView):
    authentication_classes = [JWTAuthentication]
    permission_classes = [IsAuthenticated, IsAdminUser]
    
    def get(self, request):
        admin = self.request.admin
        booth = admin.booth

        waiting_count = WaitingFilter({'status': 'waiting'}, queryset=Waiting.objects.filter(booth=booth)).qs.count()
        calling_count = WaitingFilter({'status': 'calling'}, queryset=Waiting.objects.filter(booth=booth)).qs.count()
        arrived_count = WaitingFilter({'status': 'arrived'}, queryset=Waiting.objects.filter(booth=booth)).qs.count()
        canceled_count = WaitingFilter({'status': 'canceled'}, queryset=Waiting.objects.filter(booth=booth)).qs.count()

        return custom_response(
            data={
                "waiting": waiting_count,
                "calling": calling_count,
                "arrived": arrived_count,
                "canceled": canceled_count
            },
            message="Waiting counts fetched successfully",
            code=status.HTTP_200_OK
        )
```


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
