### PR TITLE
🩹 Fix: 부스 리스트 & 디테일 - 대기 팀 수, 내 앞에 대기 팀 수, 내 waiting_id 수정 및 추가

### DIFF
--- a/booth/serializers.py
+++ b/booth/serializers.py
@@ -7,16 +7,18 @@ class BoothMenuSerializer(serializers.ModelSerializer):
         model = BoothMenu
         fields = ['name', 'price']
 
+# 부스 리스트
 class BoothListSerializer(serializers.ModelSerializer):
     thumbnail = serializers.SerializerMethodField()
-    waiting_count = serializers.SerializerMethodField()
     # 사용자 대기 관련
     is_waiting = serializers.SerializerMethodField()
     waiting_status = serializers.SerializerMethodField()
+    # 대기 팀 수 관련
+    total_waiting_teams = serializers.SerializerMethodField()
 
     class Meta:
         model = Booth
-        fields = ['id', 'name', 'description', 'location', 'is_operated', 'thumbnail', 'waiting_count', 'is_waiting', 'waiting_status']
+        fields = ['id', 'name', 'description', 'location', 'is_operated', 'thumbnail', 'total_waiting_teams', 'is_waiting', 'waiting_status']
 
     def get_thumbnail(self, obj):
         # 첫 번째 이미지가 썸네일 ! !
@@ -34,8 +36,11 @@ class BoothListSerializer(serializers.ModelSerializer):
             return request.build_absolute_uri(thumbnail.image.url)
         return ''
     
-    def get_waiting_count(self, obj):
-        return obj.waitings.count()
+    def get_total_waiting_teams(self, obj):
+        return Waiting.objects.filter(
+            booth=obj, 
+            waiting_status__in=['waiting', 'ready_to_confirm', 'confirmed']
+        ).count()
 
     # 사용자 대기 관련 
     def get_is_waiting(self, obj):
@@ -62,20 +67,41 @@ class BoothImageSerializer(serializers.ModelSerializer):
         model = BoothImage
         fields = ['image']
 
+# 부스 디테일
 class BoothDetailSerializer(serializers.ModelSerializer):
     menu = BoothMenuSerializer(many=True, source='menus')
     images = BoothImageSerializer(source='boothimages', many=True)
-    waiting_count = serializers.SerializerMethodField()
     # 사용자 대기 관련
     is_waiting = serializers.SerializerMethodField()
     waiting_status = serializers.SerializerMethodField()
+    waiting_id = serializers.SerializerMethodField()
+    # 대기 팀 수 관련
+    waiting_teams_ahead = serializers.SerializerMethodField()
+    total_waiting_teams = serializers.SerializerMethodField()
 
     class Meta:
         model = Booth
-        fields = ['id', 'name', 'description', 'location', 'caution', 'is_operated', 'images', 'menu', 'open_time', 'close_time', 'waiting_count', 'is_waiting', 'waiting_status']
+        fields = ['id', 'name', 'description', 'location', 'caution', 'is_operated', 'images', 'menu', 'open_time', 'close_time', 'total_waiting_teams', 'waiting_teams_ahead', 'is_waiting', 'waiting_id', 'waiting_status']
 
-    def get_waiting_count(self, obj):
-        return obj.waitings.count()
+    # 대기 팀 수 관련
+    def get_waiting_teams_ahead(self, obj):
+        request = self.context.get('request')
+        if request and request.user.is_authenticated:
+            current_waiting = Waiting.objects.filter(user=request.user, booth=obj).order_by('-registered_at').first()
+            if current_waiting:
+                # 현재 유저의 등록 시점보다 이전에 등록한 사람들 (waiting, ready_to_confirm, confirmed 상태만 체크)
+                return Waiting.objects.filter(
+                    booth=obj,
+                    waiting_status__in=['waiting', 'ready_to_confirm', 'confirmed'],
+                    registered_at__lt=current_waiting.registered_at
+                ).count()
+        return 0
+    
+    def get_total_waiting_teams(self, obj):
+        return Waiting.objects.filter(
+            booth=obj, 
+            waiting_status__in=['waiting', 'ready_to_confirm', 'confirmed']
+        ).count()
     
     # 사용자 대기 관련 
     def get_is_waiting(self, obj):
@@ -87,6 +113,15 @@ class BoothDetailSerializer(serializers.ModelSerializer):
                 waiting_status__in=['waiting', 'ready_to_confirm', 'confirmed']
             ).exists()
         return False
+
+    def get_waiting_id(self, obj):
+        request = self.context.get('request')
+        # is_waiting=true일 때만 waiting_id를 반환
+        if self.get_is_waiting(obj):
+            waiting = Waiting.objects.filter(user=request.user, booth=obj).order_by('-registered_at').first()
+            if waiting:
+                return waiting.id
+        return None
 
     def get_waiting_status(self, obj):
         request = self.context.get('request')

--- a/booth/views.py
+++ b/booth/views.py
@@ -39,6 +39,15 @@ class BoothViewSet(CustomResponseMixin, viewsets.GenericViewSet, mixins.Retrieve
             return custom_response({'booth_count': booth_count}, message='Booth count fetched successfully')
         except Exception as e:
             return custom_response(data=None, message=str(e), code=status.HTTP_500_INTERNAL_SERVER_ERROR, success=False)
+        
+    def retrieve(self, request, *args, **kwargs):
+        try:
+            booth = self.get_object()
+            serializer = self.get_serializer(booth)
+            return custom_response(data=serializer.data, message="Booth detail fetched successfully", code=status.HTTP_200_OK)
+        except Exception as e:
+            return custom_response(data=None, message=str(e), code=status.HTTP_500_INTERNAL_SERVER_ERROR, success=False)
+
     
     # 에러 띄우기 위한 함수
     @action(detail=False, methods=['get'], url_path='error')


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
1. 부스 리스트

- 전체 대기 팀 수가 ['waiting','ready_to_confirm','confirmed'] 이거 세 개 상태일 때만 포함되게

2. 부스 디테일

- 전체 대기 팀 수가 ['waiting','ready_to_confirm','confirmed'] 이거 세 개 상태일 때만 포함되게
- 내 앞 대기 팀 수 ['waiting','ready_to_confirm','confirmed'] 이거 세 개 상태일 때만 포함되게 , 나보다 등록 시점 앞인 팀만
- 내가 대기 중이면(is_waiting=true) waiting_id 반환

## 📸 스크린샷
### 부스 디테일
- 대기 중 아닐 때
<img width="1120" alt="스크린샷 2024-10-07 오후 12 03 00" src="https://github.com/user-attachments/assets/30669910-ea34-4727-ad0f-baeb5be67a80">

- 대기 중일 때
<img width="1120" alt="스크린샷 2024-10-07 오후 12 03 22" src="https://github.com/user-attachments/assets/b687e727-c785-42d6-bec7-af2e37b6cacf">

### 부스 리스트
<img width="1120" alt="스크린샷 2024-10-07 오후 12 03 38" src="https://github.com/user-attachments/assets/513c9103-047f-4c64-b558-d43a0d8c761b">



## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
