### PR TITLE
🩹 Fix: settings.py renderer 추가

### DIFF
--- a/booth/models.py
+++ b/booth/models.py
@@ -31,12 +31,17 @@ class Booth(models.Model):
     open_time = models.DateTimeField(verbose_name="시작 시간")
     close_time = models.DateTimeField(verbose_name="마감 시간")
 
-    def save(self, *args, **kwargs):
-        if self.is_operated == 'operating' and self.open_time is None:
-            self.open_time = timezone.now()
-        elif self.is_operated == 'finished' and self.close_time is None:
-            self.close_time = timezone.now()
-        super().save(*args, **kwargs)
+    @property
+    def is_operated(self):
+        current_time = timezone.now()
+        if self.open_time and self.close_time:
+            if self.open_time <= current_time < self.close_time:
+                return 'operating'  # 운영 시간 내이면 '운영 중'
+            elif current_time >= self.close_time:
+                return 'finished'  # 마감 시간을 넘겼으면 '운영 종료'
+            else:
+                return 'not_started'  # 아직 시작 시간이 되지 않았으면 '운영 전'
+        return 'not_started'
 
     def __str__(self):
         return self.name

--- a/linenow/settings.py
+++ b/linenow/settings.py
@@ -92,6 +92,9 @@ REST_FRAMEWORK = {
     ),
     'EXCEPTION_HANDLER': 'utils.exceptions.custom_exception_handler',
     'DEFAULT_FILTER_BACKENDS': ['django_filters.rest_framework.DjangoFilterBackend'],
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+    ),
 }
 
 REST_AUTH = {


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
Feat: 설정 시간에 따라 운영 상태 변경
Fix: settings.py renderer 추가

## 🖥️ 주요 코드 설명
```python
    @property
    def is_operated(self):
        current_time = timezone.now()
        if self.open_time and self.close_time:
            if self.open_time <= current_time < self.close_time:
                return 'operating'  # 운영 시간 내이면 '운영 중'
            elif current_time >= self.close_time:
                return 'finished'  # 마감 시간을 넘겼으면 '운영 종료'
            else:
                return 'not_started'  # 아직 시작 시간이 되지 않았으면 '운영 전'
        return 'not_started'
```


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
