### PR TITLE
✨ Feat: 부스 사용자 뷰 api 완료

### DIFF
--- a/booth/models.py
+++ b/booth/models.py
@@ -37,7 +37,7 @@ class Booth(models.Model):
     
 class Booth_Menu(models.Model):
     menu_id = models.AutoField(primary_key=True)
-    booth = models.ForeignKey(Booth, on_delete=models.CASCADE, related_name="menus")
+    booth = models.ForeignKey(Booth, on_delete=models.CASCADE, related_name="booth_menus")
     menu_name = models.CharField(max_length=100, verbose_name="메뉴 이름")
     menu_price = models.IntegerField(verbose_name="메뉴 가격")
 
@@ -46,7 +46,7 @@ class Booth_Menu(models.Model):
     
 class Booth_Image(models.Model):
     booth_image_id = models.AutoField(primary_key=True)
-    booth = models.ForeignKey(Booth, on_delete=models.CASCADE, related_name="boothimages")
+    booth = models.ForeignKey(Booth, on_delete=models.CASCADE, related_name="booth_images")
     booth_image = models.ImageField(upload_to=image_upload_path, blank=True, null=True, verbose_name="사진")
     
     def __str__(self):

--- a/booth/serializers.py
+++ b/booth/serializers.py
@@ -5,22 +5,22 @@ from waiting.models import Waiting
 class Booth_MenuSerializer(serializers.ModelSerializer):
     class Meta:
         model = Booth_Menu
-        fields = ['name', 'price']
+        fields = ['menu_id', 'menu_name', 'menu_price']
 
-# 부스 리스트
+class Booth_ImageSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Booth_Image
+        fields = ['booth_image_id', 'booth_image']
+
 class BoothListSerializer(serializers.ModelSerializer):
     thumbnail = serializers.SerializerMethodField()
-    # 사용자 대기 관련
-    waiting_status = serializers.SerializerMethodField()
-    # 대기 팀 수 관련
-    total_waiting_teams = serializers.SerializerMethodField()
 
     class Meta:
         model = Booth
-        fields = ['booth_id', 'booth_name', 'booth_description', 'booth_location', 'operating_status', 'thumbnail', 'total_waiting_teams', 'waiting_status']
+        fields = ['booth_id', 'booth_name', 'booth_description', 'booth_location', 'operating_status', 'thumbnail']
 
     def get_thumbnail(self, obj):
-        # 첫 번째 이미지가 썸네일 ! !
+        # 첫 번째 이미지가 썸네일
         
         # 상대 경로 반환
         # thumbnail = obj.Booth_Images.first()
@@ -30,102 +30,105 @@ class BoothListSerializer(serializers.ModelSerializer):
         
         # 절대 경로 반환
         request = self.context.get('request')
-        thumbnail = obj.Booth_Images.first()
+        thumbnail = obj.booth_images.first()
         if thumbnail and request:
-            return request.build_absolute_uri(thumbnail.image.url)
+            return request.build_absolute_uri(thumbnail.booth_image.url)
         return ''
     
+class BoothWaitingListSerializer(serializers.ModelSerializer):
+    waiting_id = serializers.SerializerMethodField()
+    total_waiting_teams = serializers.SerializerMethodField() # 전체 대기 팀
+    waiting_status = serializers.SerializerMethodField() # 현재 대기 상태
+
+    class Meta:
+        model = Booth
+        fields = ['booth_id', 'waiting_id', 'total_waiting_teams', 'waiting_status']
+
+    def get_waiting_id(self, obj):
+        print("id")
+        request = self.context.get('request')
+        if request and request.user.is_authenticated:
+            waiting = Waiting.objects.filter(user=request.user, booth=obj).order_by('-created_at').first()
+            return waiting.waiting_id
+        return None
+
+    def get_total_waiting_teams(self, obj):
+        print("team")
+        return Waiting.objects.filter(
+            booth=obj, 
+            waiting_status__in=['waiting', 'entering']
+        ).count()
+
+    # 여러 번 대기를 걸었을 때 가장 최근의 status를 반영
+    def get_waiting_status(self, obj):
+        print("status")
+        request = self.context.get('request')
+        if request and request.user.is_authenticated:
+            waiting = Waiting.objects.filter(user=request.user, booth=obj).order_by('-created_at').first()
+            if waiting:
+                return waiting.waiting_status
+        return None
+
+class BoothDetailSerializer(serializers.ModelSerializer):
+    menu_info = Booth_MenuSerializer(many=True, source='booth_menus')
+    booth_image_info = Booth_ImageSerializer(source='booth_images', many=True)
+
+    class Meta:
+        model = Booth
+        fields = ['booth_id', 'booth_name', 'booth_description', 'booth_location', 'booth_notice', 'operating_status', 'booth_start_time', 'menu_info', 'booth_image_info']
+
+class BoothWaitingDetailSerializer(serializers.ModelSerializer):
+    waiting_id = serializers.SerializerMethodField()
+    total_waiting_teams = serializers.SerializerMethodField() # 전체 대기 팀
+    waiting_status = serializers.SerializerMethodField() # 현재 대기 상태
+    waiting_team_ahead = serializers.SerializerMethodField() # 현재 대기 상태
+    confirmed_at = serializers.SerializerMethodField() # 입장 승인 시간
+
+    class Meta:
+        model = Booth
+        fields = ['booth_id', 'waiting_id', 'total_waiting_teams', 'waiting_status', 'waiting_team_ahead', 'confirmed_at']
+
+    def get_waiting_id(self, obj):
+        request = self.context.get('request')
+        if request and request.user.is_authenticated:
+            waiting = Waiting.objects.filter(user=request.user, booth=obj).order_by('-created_at').first()
+            return waiting.waiting_id
+        return None
+
     def get_total_waiting_teams(self, obj):
         return Waiting.objects.filter(
             booth=obj, 
             waiting_status__in=['waiting', 'entering']
         ).count()
 
-    # 사용자 대기 관련 
-    def get_is_waiting(self, obj):
-        request = self.context.get('request')
-        if request and request.user.is_authenticated:
-            return Waiting.objects.filter(
-                user=request.user, 
-                booth=obj,
-                waiting_status__in=['waiting', 'entering']
-            ).exists()
-        return False
-
     # 여러 번 대기를 걸었을 때 가장 최근의 status를 반영
     def get_waiting_status(self, obj):
         request = self.context.get('request')
         if request and request.user.is_authenticated:
-            waiting = Waiting.objects.filter(user=request.user, booth=obj).order_by('-registered_at').first()
+            waiting = Waiting.objects.filter(user=request.user, booth=obj).order_by('-created_at').first()
             if waiting:
                 return waiting.waiting_status
         return None
-    
-class Booth_ImageSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Booth_Image
-        fields = ['booth_image']
 
-# 부스 디테일
-class BoothDetailSerializer(serializers.ModelSerializer):
-    menu = Booth_MenuSerializer(many=True, source='menus')
-    images = Booth_ImageSerializer(source='Booth_Images', many=True)
-    # 사용자 대기 관련
-    is_waiting = serializers.SerializerMethodField()
-    waiting_status = serializers.SerializerMethodField()
-    waiting_id = serializers.SerializerMethodField()
-    # 대기 팀 수 관련
-    waiting_teams_ahead = serializers.SerializerMethodField()
-    total_waiting_teams = serializers.SerializerMethodField()
+    def get_waiting_team_ahead(self, obj):
+        request = self.context.get('request')
+        if request and request.user.is_authenticated:
+            waiting = Waiting.objects.filter(user=request.user, booth=obj).order_by('-created_at').first()
+            return Waiting.objects.filter(booth=obj, 
+                created_at__lt=obj.created_at,
+                waiting_status__in=['waiting', 'entering']
+            ).count()
+        return None
 
+    def get_confirmed_at(self, obj):
+        request = self.context.get('request')
+        if request and request.user.is_authenticated:
+            waiting = Waiting.objects.filter(user=request.user, booth=obj).order_by('-created_at').first()
+            if waiting:
+                return waiting.confirmed_at
+        return None
+
+class BoothLocationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Booth
-        fields = ['id', 'name', 'description', 'location', 'caution', 'is_operated', 'images', 'menu', 'open_time', 'close_time', 'total_waiting_teams', 'waiting_teams_ahead', 'is_waiting', 'waiting_id', 'waiting_status']
-
-    # 대기 팀 수 관련
-    def get_waiting_teams_ahead(self, obj):
-        request = self.context.get('request')
-        if request and request.user.is_authenticated:
-            current_waiting = Waiting.objects.filter(user=request.user, booth=obj).order_by('-registered_at').first()
-            if current_waiting:
-                # 현재 유저의 등록 시점보다 이전에 등록한 사람들 (waiting, ready_to_confirm, confirmed 상태만 체크)
-                return Waiting.objects.filter(
-                    booth=obj,
-                    waiting_status__in=['waiting', 'ready_to_confirm', 'confirmed'],
-                    registered_at__lt=current_waiting.registered_at
-                ).count()
-        return 0
-    
-    def get_total_waiting_teams(self, obj):
-        return Waiting.objects.filter(
-            booth=obj, 
-            waiting_status__in=['waiting', 'ready_to_confirm', 'confirmed']
-        ).count()
-    
-    # 사용자 대기 관련 
-    def get_is_waiting(self, obj):
-        request = self.context.get('request')
-        if request and request.user.is_authenticated:
-            return Waiting.objects.filter(
-                user=request.user, 
-                booth=obj,
-                waiting_status__in=['waiting', 'ready_to_confirm', 'confirmed']
-            ).exists()
-        return False
-
-    def get_waiting_id(self, obj):
-        request = self.context.get('request')
-        # is_waiting=true일 때만 waiting_id를 반환
-        if self.get_is_waiting(obj):
-            waiting = Waiting.objects.filter(user=request.user, booth=obj).order_by('-registered_at').first()
-            if waiting:
-                return waiting.id
-        return None
-
-    def get_waiting_status(self, obj):
-        request = self.context.get('request')
-        if request and request.user.is_authenticated:
-            waiting = Waiting.objects.filter(user=request.user, booth=obj).order_by('-registered_at').first()
-            if waiting:
-                return waiting.waiting_status
-        return None
+        fields = ['booth_id', 'booth_latitude', 'booth_longitude', 'operating_status']

--- a/booth/urls.py
+++ b/booth/urls.py
@@ -1,13 +1,17 @@
 from django.urls import path, include
 from rest_framework import routers
 
-from .views import BoothViewSet
+from .views import BoothViewSet, BoothWaitingStatusViewSet
 
 app_name = 'booth'
 
 booth_router = routers.SimpleRouter(trailing_slash=False)
 booth_router.register(r'booths', BoothViewSet, basename='booth')
 
+booth_waiting_router = routers.SimpleRouter(trailing_slash=False)
+booth_waiting_router.register(r'booths-waiting', BoothWaitingStatusViewSet, basename='booth-waiting')
+
 urlpatterns = [
     path('', include(booth_router.urls)),
+    path('', include(booth_waiting_router.urls)),
 ]

--- a/linenow/settings.py
+++ b/linenow/settings.py
@@ -96,6 +96,7 @@ REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': ['django_filters.rest_framework.DjangoFilterBackend'],
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
+        'rest_framework.renderers.BrowsableAPIRenderer'
     ),
 }
 


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
사용자 뷰 부스 api 완료했습니다.
부스 정보 부분, 대기 정보 부분 분리하여 api 구현했습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->


## 📸 스크린샷
<!-- 구현한 기능의 웹 혹은 postman을 캡쳐해주세요. -->


## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
- 쏼라쏼라
```python
class BoothWaitingStatusViewSet(CustomResponseMixin, viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.ListModelMixin):

    def get_serializer_class(self):
        if self.action == 'list':
            return BoothWaitingListSerializer 
        return BoothWaitingDetailSerializer 

    def get_queryset(self):
        # 운영 상태에 따른 정렬 우선순위 설정 ! '운영 중 - 대기 중지 - 운영 전 - 운영종료' 순
        queryset = Booth.objects.annotate(
            # 'waiting', 'entering' 상태만 카운트
            # waiting_count=Count('waitings', filter=Q(waitings__waiting_status__in=['waiting', 'entering'])),
            operating_status_order=Case(
                When(operating_status='operating', then=Value(1)),
                When(operating_status='paused', then=Value(2)),
                When(operating_status='not_started', then=Value(3)),
                When(operating_status='finished', then=Value(4)),
                output_field=IntegerField()
            )
        )
        # 운영 상태 + 이름 순 정렬
        return queryset.order_by('operating_status_order', 'booth_name')

    def retrieve(self, request, *args, **kwargs):
        try:
            booth = self.get_object()
            serializer = self.get_serializer(booth)
            return custom_response(data=serializer.data, message="Booth detail fetched successfully", code=status.HTTP_200_OK)
        except Exception as e:
            return custom_response(data=None, message=str(e), code=status.HTTP_500_INTERNAL_SERVER_ERROR, success=False)
```


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?


## 📟 관련 이슈
- Resolved: #이슈번호
