### PR TITLE
Fix: 관리자 대기 목록 정렬 변경

### DIFF
--- a/manager/views.py
+++ b/manager/views.py
@@ -219,6 +219,7 @@ class ManagerViewSet(viewsets.ViewSet):
             # 취소된 대기는 뒤로 정렬
             queryset = Waiting.objects.filter(booth=booth).annotate(
                 canceled_waiting=Case(
+                    When(waiting_status__in=['entered'], then=Value(2)),
                     When(waiting_status__in=['canceled', 'time_over'], then=Value(1)),
                     default=Value(0),
                     output_field=IntegerField(),


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
관리자 대기 목록에서 입장 완료는 맨 뒤로 가도록 수정했습니다.


## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->


## 📸 스크린샷
<!-- 구현한 기능의 웹 혹은 postman을 캡쳐해주세요. -->


## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
- 쏼라쏼라
```python
// 코드는 이 사이에 작성하면 됩니다. 
```


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?


## 📟 관련 이슈
- Resolved: #이슈번호
